### PR TITLE
getEventByRevision for mongodb and tingodb

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -100,6 +100,17 @@ _.extend(Store.prototype, {
   },
 
   /**
+   * loads one event for an aggregate id with a specific revision
+   * @param {Object}   query    the query object
+   * @param {Number}   rev      revision
+   * @param {Function} callback the function that will be called when this action has finished
+   *                            `function(err, event){}`
+   */
+  getEventByRevision: function (query, revMin, revMax, callback) {
+    implementError(callback);
+  },
+
+  /**
    * loads the next snapshot back from given max revision
    * @param {Object}   query    the query object
    * @param {Number}   revMax   revision end point (hint: -1 = to end)

--- a/lib/databases/inmemory.js
+++ b/lib/databases/inmemory.js
@@ -11,7 +11,7 @@ function InMemory(options) {
   this.undispatchedEvents = { _direct: {} };
   this.options = options;
   if (options.trackPosition)
-    this.position = 0;    
+    this.position = 0;
 }
 
 util.inherits(InMemory, Store);
@@ -67,7 +67,7 @@ _.extend(InMemory.prototype, {
     if (!this.options.trackPosition) {
       return callback(null);
     }
-    
+
     var range = [];
     for(var i=0; i<positions; i++) {
       range.push(++this.position);

--- a/lib/databases/mongodb.js
+++ b/lib/databases/mongodb.js
@@ -69,7 +69,7 @@ function streamEventsByRevision(self, findStatement, revMin, revMax, resultStrea
     });
   });
 };
-  
+
 function Mongo(options) {
   options = options || {};
 
@@ -190,7 +190,7 @@ _.extend(Mongo.prototype, {
           function (err) { if (err) { debug(err); } });
         self.events[ensureIndex]({ commitStamp: 1, streamRevision: 1, commitSequence: 1 },
           function (err) { if (err) { debug(err); } });
-  
+
         self.snapshots = self.db.collection(options.snapshotsCollectionName);
         self.snapshots[ensureIndex]({ aggregateId: 1, revision: -1 },
           function (err) { if (err) { debug(err); } });
@@ -404,7 +404,7 @@ _.extend(Mongo.prototype, {
     if (skip) {
       query.skip(skip);
     }
-    
+
     if (limit && limit > 0) {
       query.limit(limit);
     }
@@ -419,10 +419,10 @@ _.extend(Mongo.prototype, {
 
     if (skip)
       query.skip(skip);
-    
+
     if (limit && limit > 0)
       query.limit(limit);
-    
+
     return query;
   },
 
@@ -677,7 +677,7 @@ _.extend(Mongo.prototype, {
             goodTxs.push(evt);
             return clb(null);
           }
-          
+
           self.transactions.deleteOne({ _id: tx._id }, clb);
         });
       }, function (err) {
@@ -710,6 +710,45 @@ _.extend(Mongo.prototype, {
     }
 
     this.events.findOne(findStatement, { sort: [['commitStamp', 'desc'], ['streamRevision', 'desc'], ['commitSequence', 'desc']] }, callback);
+  },
+
+  getEventByRevision: function (query, rev, callback) {
+    if (!query.aggregateId) {
+      var errMsg = 'aggregateId not defined!';
+      debug(errMsg);
+      if (callback) callback(new Error(errMsg));
+      return;
+    }
+
+    if (typeof rev === 'function') {
+      callback = rev;
+      var errMsg = 'streamRevision not defined!';
+      debug(errMsg);
+      if (callback) callback(new Error(errMsg));
+      return;
+    }
+
+    if (typeof rev !== 'number') {
+      var errMsg = 'streamRevision not defined!';
+      debug(errMsg);
+      if (callback) callback(new Error(errMsg));
+      return;
+    }
+
+    var findStatement = {
+      aggregateId: query.aggregateId,
+      streamRevision: rev
+    };
+
+    if (query.aggregate) {
+      findStatement.aggregate = query.aggregate;
+    }
+
+    if (query.context) {
+      findStatement.context = query.context;
+    }
+
+    this.events.findOne(findStatement, callback);
   },
 
   repairFailedTransaction: function (lastEvt, callback) {

--- a/lib/databases/tingodb.js
+++ b/lib/databases/tingodb.js
@@ -442,6 +442,48 @@ _.extend(Tingo.prototype, {
     this.events.findOne(findStatement, { sort: [['commitStamp', 'desc'], ['streamRevision', 'desc'], ['commitSequence', 'desc']] }, callback);
   },
 
+  getEventByRevision: function (query, rev, callback) {
+    if (!query.aggregateId) {
+      var errMsg = 'aggregateId not defined!';
+      debug(errMsg);
+      if (callback) callback(new Error(errMsg));
+      return;
+    }
+
+    if (typeof rev === 'function') {
+      callback = rev;
+      var errMsg = 'streamRevision not defined!';
+      debug(errMsg);
+      if (callback) callback(new Error(errMsg));
+      return;
+    }
+
+    if (typeof rev !== 'number') {
+      var errMsg = 'streamRevision not defined!';
+      debug(errMsg);
+      if (callback) callback(new Error(errMsg));
+      return;
+    }
+
+    var findStatement = {
+      '$or': [
+        { aggregateId: query.aggregateId },
+        { streamId: query.aggregateId } // just for compatability of < 1.0.0
+      ],
+      streamRevision: rev
+    };
+
+    if (query.aggregate) {
+      findStatement.aggregate = query.aggregate;
+    }
+
+    if (query.context) {
+      findStatement.context = query.context;
+    }
+
+    this.events.findOne(findStatement, callback);
+  },
+
   repairFailedTransaction: function (lastEvt, callback) {
     var self = this;
 

--- a/lib/eventstore.js
+++ b/lib/eventstore.js
@@ -128,7 +128,7 @@ _.extend(Eventstore.prototype, {
     if (typeof query === 'number') {
       limit = skip;
       skip = query;
-      query = {};      
+      query = {};
     };
 
     if (typeof query === 'string') {
@@ -570,6 +570,28 @@ _.extend(Eventstore.prototype, {
     }
 
     this.store.getLastEvent(query, callback);
+  },
+
+  /**
+   * loads one event for an aggregate id with a specific revision
+   * @param {Object || String} query    the query object
+   * @param {Number}           revMin   revision
+   * @param {Function}         callback the function that will be called when this action has finished
+   *                                    `function(err, event){}`
+   */
+  getEventByRevision: function (query, rev, callback) {
+    if (typeof query === 'string') {
+      query = { aggregateId: query };
+    }
+
+    if (!query.aggregateId) {
+      var err = new Error('An aggregateId should be passed!');
+      debug(err);
+      if (callback) callback(err);
+      return;
+    }
+
+    this.store.getEventByRevision(query, rev, callback);
   },
 
   /**

--- a/test/storeTest.js
+++ b/test/storeTest.js
@@ -63,6 +63,7 @@ types.forEach(function (type) {
         if (type === 'mongodb' || type === 'tingodb') {
           expect(store.getPendingTransactions).to.be.a('function');
           expect(store.getLastEvent).to.be.a('function');
+          expect(store.getEventsByRevision).to.be.a('function');
           expect(store.repairFailedTransaction).to.be.a('function');
         }
       });
@@ -2358,6 +2359,89 @@ types.forEach(function (type) {
               });
 
             });
+
+            if (type === 'mongodb' || type === 'tingodb') {
+
+              describe('calling getEventByRevision', function () {
+
+                describe('with an aggregateId being used only in one context and aggregate', function () {
+
+                  it('it should return the correct events', function (done) {
+
+                    store.getEventByRevision({ aggregateId: 'idWithAgg' }, 1, function (err, evt) {
+                      expect(err).not.to.be.ok();
+                      expect(evt.aggregateId).to.eql(stream2[1].aggregateId);
+                      expect(evt.commitStamp.getTime()).to.eql(stream2[1].commitStamp.getTime());
+                      expect(evt.streamRevision).to.eql(stream2[1].streamRevision);
+                      done();
+                    });
+
+                  });
+
+                });
+
+                describe('omitting the revision', function () {
+
+                  it('it should fail due to an error thrown', function (done) {
+
+                    store.getEventByRevision({ aggregateId: 'idWithAgg' }, function (err, _evt) {
+                      expect(err).to.be.ok();
+                      done();
+                    });
+
+                  });
+
+                });
+
+                describe('with an aggregateId being used in an other context or aggregate', function () {
+
+                  it('it should return the correct events', function (done) {
+
+                    store.getEventByRevision({ aggregateId: 'id' }, 0, function (err, evt) {
+                      expect(err).not.to.be.ok();
+                      expect(evt.aggregateId).to.eql(stream1[0].aggregateId);
+                      expect(evt.commitStamp.getTime()).to.eql(stream1[0].commitStamp.getTime());
+                      expect(evt.streamRevision).to.eql(stream1[0].streamRevision);
+                      done();
+                    });
+
+                  });
+
+                });
+
+                describe('with an aggregateId and with an aggregate', function () {
+
+                  it('it should return the correct events', function (done) {
+
+                    store.getEventByRevision({ aggregate: 'myAggrrr2', aggregateId: 'idWithAggrAndCont' }, 0, function (err, evt) {
+                      expect(err).not.to.be.ok();
+                      expect(evt.aggregateId).to.eql(stream9[0].aggregateId);
+                      expect(evt.commitStamp.getTime()).to.eql(stream9[0].commitStamp.getTime());
+                      expect(evt.streamRevision).to.eql(stream9[0].streamRevision);
+                      done();
+                    });
+
+                  });
+                });
+
+                describe('with an aggregateId and without an aggregate but with a context', function () {
+
+                  it('it should return the correct events', function (done) {
+
+                    store.getEventByRevision({ aggregateId: 'idWithAggrAndCont', context: 'myConttttt' }, 1, function (err, evt) {
+                      expect(err).not.to.be.ok();
+                      expect(evt.aggregateId).to.eql(stream6[1].aggregateId);
+                      expect(evt.commitStamp.getTime()).to.eql(stream6[1].commitStamp.getTime());
+                      expect(evt.streamRevision).to.eql(stream6[1].streamRevision);
+                      done();
+                    });
+
+                  });
+
+                });
+
+              });
+            }
 
           });
 


### PR DESCRIPTION
haven't updated the readme due to not having it implemented for all db's yet.